### PR TITLE
Configura o client HTTP com tiemout de 2s para início da conexão

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,11 @@ import os
 ENV = "TEST"
 os.environ["ENV"] = ENV
 
-VALUES = {"MESOS_MASTER_URLS": json.dumps(["http://127.0.0.1:5050"])}
+VALUES = {
+    "MESOS_MASTER_URLS": json.dumps(
+        ["http://127.0.0.1:5050", "http://10.0.0.1:5050"]
+    )
+}
 
 
 for name, value in VALUES.items():

--- a/indexer/mesos/events/consumer.py
+++ b/indexer/mesos/events/consumer.py
@@ -1,7 +1,8 @@
 import json
-from typing import AsyncGenerator, List, Optional
+from typing import AsyncGenerator, Optional
 
 from aiohttp import ClientSession
+from aiohttp.client import ClientTimeout
 from pydantic import ValidationError
 
 from indexer.conf import logger
@@ -14,7 +15,8 @@ from indexer.mesos.models.converters.taskupdated import (
     MesosTaskUpdatedEventConverter,
 )
 from indexer.mesos.models.event import MesosEventTypes, MesosEvent
-from indexer.models.event import Event
+
+timeout_config = ClientTimeout(connect=2.0)
 
 
 class MesosEventConsumer(Consumer):
@@ -22,7 +24,7 @@ class MesosEventConsumer(Consumer):
         Consumer.__init__(self, conn)
 
     async def connect(self) -> None:
-        client = ClientSession()
+        client = ClientSession(timeout=timeout_config)
         for url in self.conn.urls:
             resp = await client.post(
                 f"{url}/api/v1", json={"type": "SUBSCRIBE"}

--- a/tests/conf_test.py
+++ b/tests/conf_test.py
@@ -4,4 +4,7 @@ from tests.base import BaseTestCase
 
 class ConfTest(BaseTestCase):
     async def test_load_mesos_urls(self):
-        self.assertEqual(settings.MESOS_MASTER_URLS, ["http://127.0.0.1:5050"])
+        self.assertEqual(
+            settings.MESOS_MASTER_URLS,
+            ["http://127.0.0.1:5050", "http://10.0.0.1:5050"],
+        )

--- a/tests/mesos_events_consumer_test.py
+++ b/tests/mesos_events_consumer_test.py
@@ -1,5 +1,6 @@
 import json
 
+from aiohttp.client import ClientTimeout
 from aiohttp.web import Request, StreamResponse
 from aioresponses import aioresponses
 from asynctest import mock
@@ -226,3 +227,19 @@ class MesosConsumerTest(BaseTestCase):
             )
             await consumer.connect()
             client_session_mock.assert_called_with(timeout=timeout_config)
+
+    async def test_use_next_mesos_urls_if_needed(self):
+        with aioresponses() as rsps:
+            rsps.post(
+                f"{settings.MESOS_MASTER_URLS[0]}/api/v1",
+                exception=ClientTimeout("timeout"),
+            )
+            rsps.post(
+                f"{settings.MESOS_MASTER_URLS[1]}/api/v1",
+                exception=ClientTimeout("timeout"),
+            )
+            consumer = MesosEventConsumer(
+                HTTPConnection(urls=settings.MESOS_MASTER_URLS)
+            )
+            await consumer.connect()
+        self.assertTrue(True)


### PR DESCRIPTION
Se a conexão TCP não se estabelecer em no máximo 2s, um timeout será
lançado.