### PR TITLE
Usando o nome real da task do Chronos

### DIFF
--- a/indexer/mesos/models/converters/util.py
+++ b/indexer/mesos/models/converters/util.py
@@ -22,8 +22,10 @@ def split_task_id(task_id: str, split_type: SplitType) -> Tuple[str, str, str]:
     job_name_parts = job_name.split("-")
     namespace = job_name_parts[0]
     appname = "-".join(job_name_parts[1:])
-    # No caso do Chronos o task_name e appname são iguais
-    return namespace, appname, appname
+
+    task_name_without_ns = ":".join([prefix, time, try_count, appname])
+
+    return namespace, appname, task_name_without_ns
 
 
 def get_task_namespace(task_id: str) -> str:

--- a/tests/mesos_events_consumer_test.py
+++ b/tests/mesos_events_consumer_test.py
@@ -187,7 +187,7 @@ class MesosConsumerTest(BaseTestCase):
             "appname": "heimdall",
             "namespace": "asgard",
             "backend_info": {"name": BackendInfoTypes.CHRONOS},
-            "task": {"id": "heimdall"},
+            "task": {"id": "ct:1578593280013:0:heimdall"},
             "agent": {"id": "79ad3a13-b567-4273-ac8c-30378d35a439-S6563"},
             "status": "TASK_FINISHED",
             "source": EventSourceSpec.SOURCE_EXECUTOR,

--- a/tests/mesos_model_converter_task_updated_test.py
+++ b/tests/mesos_model_converter_task_updated_test.py
@@ -49,7 +49,7 @@ class MesosTaskUpdatedConverterTest(BaseTestCase):
             "appname": "heimdall",
             "namespace": "asgard",
             "backend_info": {"name": BackendInfoTypes.CHRONOS},
-            "task": {"id": "heimdall"},
+            "task": {"id": "ct:1578593280013:0:heimdall"},
             "agent": {"id": "79ad3a13-b567-4273-ac8c-30378d35a439-S6563"},
             "status": "TASK_FINISHED",
             "source": EventSourceSpec.SOURCE_EXECUTOR,
@@ -107,7 +107,7 @@ class MesosTaskUpdatedConverterTest(BaseTestCase):
             "namespace": "asgard",
             "source": EventSourceSpec.SOURCE_EXECUTOR,
             "status": TaskStatus.TASK_RUNNING,
-            "task": {"id": "heimdall"},
+            "task": {"id": "ct:1578667560007:0:heimdall"},
             "container_info": {
                 "pid": 32306,
                 "running": True,

--- a/tests/mesos_model_converter_util_test.py
+++ b/tests/mesos_model_converter_util_test.py
@@ -31,13 +31,13 @@ class MesosEventModelConverterUtilTest(BaseTestCase):
             ),
         )
         self.assertEqual(
-            "heimdall-other-app",
+            "ct:1578492720011:0:heimdall-other-app",
             remove_task_namespace(
                 "ct:1578492720011:0:asgard-heimdall-other-app:"
             ),
         )
         self.assertEqual(
-            "heimdall",
+            "ct:1578492720011:0:heimdall",
             remove_task_namespace("ct:1578492720011:0:asgard-heimdall:"),
         )
 


### PR DESCRIPTION
Dessa forma conseguimos ter o rastro de eventos de uma mesma task. Basta
filtrar pelo task.id